### PR TITLE
Update keycloak-config.service.ts

### DIFF
--- a/example/src/config/keycloak-config.service.ts
+++ b/example/src/config/keycloak-config.service.ts
@@ -6,7 +6,7 @@ export class KeycloakConfigService implements KeycloakConnectOptionsFactory {
 
   createKeycloakConnectOptions(): KeycloakConnectOptions {
     return {
-      authServerUrl: 'http://localhost:8180/auth',
+      authServerUrl: 'http://localhost:8180',
       realm: 'nest-example',
       clientId: 'nest-api',
       secret: '05c1ff5e-f9ba-4622-98e3-c4c9d280546e',


### PR DESCRIPTION
In the latest version of keycloak, auth url has been changed to http://localhost:8180 from http://localhost:8180/auth